### PR TITLE
Missing sensu_ prefix on Redis package vars

### DIFF
--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -6,8 +6,8 @@
 
   - name: Ensure redis is installed
     dnf:
-      name: "{{ redis_pkg_name }}"
-      state: "{{ redis_pkg_state }}"
+      name: "{{ sensu_redis_pkg_name }}"
+      state: "{{ sensu_redis_pkg_state }}"
 
   - name: Ensure redis binds to accessible IP
     lineinfile:


### PR DESCRIPTION
Apologies for making this more complicated, but wanted to help get [#141](https://github.com/sensu/sensu-ansible/pull/141) across the line. Just adding a couple of prefixes in the Fedora redis task - which just added after you originally submitted your PR.

If you can merge this, it'll get into the upstream and we should be good to go. 

Thanks!